### PR TITLE
Fix non-aura metadata save from within document

### DIFF
--- a/lightningsave.py
+++ b/lightningsave.py
@@ -1018,10 +1018,15 @@ class LightningSave(sublime_plugin.EventListener):
             if Helper.is_static_resource(self, filename):
                 print("is static resource")
             else:
-                command = '-f="' + filename + '"'
                 view.window().run_command(
                     'exec',
-                    {'cmd': ["force", "push", command]})
+                    {
+                        'working_dir':
+                            os.path.dirname(
+                                os.path.dirname(
+                                    os.path.dirname(filename))),
+                        'cmd': ["force", "push", "-f", filename]
+                    })
         elif Helper.is_static_resource(self, os.path.dirname(filename)):
             resource_name = Helper.get_resource_name(self, filename)
             command = '-t=StaticResource'


### PR DESCRIPTION
This resolves an error which occurs at least in Sublime Text 3 (occurring at least on Windows 10 and Debian Jessie), where non-aura metadata (ApexClass, etc) would be unsuccessfully pushed on save from within the opened metadata. 

The issue is resolved by passing the working dir into the sublime exec command (as the working dir is treated as an input in the Force CLI ```push``` command) and by changing how the filename is passed.

Without the use of a working dir at the parent directory of the metadata directory (the current behavior), I receive the following exception:

```
Validating and deploying push...
ERROR: Current directory does not contain a metadata or src directory
[Finished in 0.1s with exit code 1]
[cmd: ['force', 'push', '-f=C:\\dev\\MyOrg\\metadata\\classes\\MyClass.cls']]
```

Without a change to how the argument is passed, I receive the following exception

```
Validating and deploying push...
GetFileAttributesEx C:\dev\MyOrg\"C:\dev\MyOrg\metadata\classes\MyClass.cls": The filename, directory name, or volume label syntax is incorrect.
ERROR: Could not add the following files:
 {}
%!(EXTRA string="C:\dev\MyOrg\metadata\classes\MyClass.cls")[Finished in 0.1s with exit code 1]
[cmd: ['force', 'push', '-f="C:\\dev\\MyOrg\\metadata\\classes\\MyClass.cls"']]
```
