### PR TITLE
Support src metadata dirs

### DIFF
--- a/lightningsave.py
+++ b/lightningsave.py
@@ -87,7 +87,7 @@ class Helper(sublime_plugin.WindowCommand):
 
     def is_metadata(self, working_dir):
         """Sample doc string."""
-        return os.path.basename(os.path.dirname(working_dir)) == "metadata"
+        return os.path.basename(os.path.dirname(working_dir)) in ["metadata", "src"]
 
     def is_static_resource(self, file):
         """Sample doc string."""


### PR DESCRIPTION
The force.com CLI supports the use of "src/" as the metadata directory for the working directory. 

Supporting this, in addition to "metadata/," in Sublime Lightning is a net benefit to the project:nearly all previous IDEs for salesforce (including the Force.Com IDE) assume a "src/" directory. 

By supporting saves of metadata in the "src/" directory, Sublime Lightning ensures that end-users do not have to choose between their repositories support Sublime Lightning or supporting most other IDEs (e.g. having to hold off on anyone in the organization using Sublime Lightning until a coordinated "switch") or have their repositories depend on non-windows-compatible symlinks.