### PR TITLE
Handle None ruleId values returned by "parsing error" results

### DIFF
--- a/auralint.py
+++ b/auralint.py
@@ -82,7 +82,10 @@ class LightningLintCommand(sublime_plugin.TextCommand):
             for mm in m:
                 data = mm['result']
                 for res in data:
-                    x = [mm['file'], res['ruleId'] + " " +
+                    rule_id = ''
+                    if res['ruleId'] != None:
+                        rule_id = res['ruleId'] + ' '
+                    x = [mm['file'], rule_id +
                          res['message'],
                          res['source'].strip(),
                          str(res['line']), str(res['column'])]


### PR DESCRIPTION
The lightning CLI, when returning a parsing error result (like a missing bracket) in its JSON results, will provide a null (loaded as None) as the result's "ruleId."

Currently, the lint code will fail in this scenario, with the following error message:

`TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'`

This commit adds a check to the ruleId field in the result if it is none. If it is none, instead of providing the result 'ruleId' joined by a space with the result 'message' as the error message, only the result 'message' is used.

The commit can be tested by trying to save this as a controller:

```
({
    init: function(){
    };
})
```
