### PR TITLE
call Heroku Toolbelt in shell mode on windows

### DIFF
--- a/auralint.py
+++ b/auralint.py
@@ -6,6 +6,7 @@ Check Lightning JS files with
 """
 import json
 import os
+import shlex
 import subprocess
 
 import sublime
@@ -15,7 +16,7 @@ import sublime_plugin
 settings = sublime.load_settings("Lightning.sublime-settings")
 FLAKE_DIR = os.path.dirname(os.path.abspath(__file__))
 ERRORS_IN_VIEWS = {}
-
+IS_WINDOWS = os.name == 'nt'
 
 def update_statusbar(view):
     """Update status bar with error."""
@@ -64,10 +65,12 @@ class LightningLintCommand(sublime_plugin.TextCommand):
 
         folders = self.view.window().folders()
         print("Folders are " + folders[0])
+        quote = lambda x: shlex.quote(x) if IS_WINDOWS else x
         p = subprocess.Popen(["heroku", "lightning:lint",
-                             folders[0], "--files", filename, "--json"],
+                             quote(folders[0]), "--files", quote(filename), "--json"],
                              stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
+                             stderr=subprocess.PIPE,
+                             shell=IS_WINDOWS)
         print("Calling for results.")
         results, err = p.communicate()
         if err:


### PR DESCRIPTION
In Windows, currently even if the heroku toolbelt executable is in the system or user PATH, attempts to call it will result in error as by default ```subprocess.Popen()``` does not have access to the PATH on windows, and because of this will not find the executable, resulting in the error message appended below.

There are a couple ways to solve this (like ```shutil.which```), the approach I've chosen is to, on windows, call Popen() with the ```shell=true``` arg. On windows, when ```subprocess.Popen()``` is called without this argument, it can cause a cmd window to pop up.

```
Traceback (most recent call last):
  File "C:\Program Files\Sublime Text 3\sublime_plugin.py", line 574, in run_
    return self.run(edit)
  File "C:\Users\test\AppData\Roaming\Sublime Text 3\Packages\Lightning\auralint.py", line 70, in run
    stderr=subprocess.PIPE)
  File "./python3.3/subprocess.py", line 819, in __init__
  File "./python3.3/subprocess.py", line 1110, in _execute_child
FileNotFoundError: [WinError 2] The system cannot find the file specified
```